### PR TITLE
fix: make replica timeout configurable

### DIFF
--- a/.github/workflows/azure-devops-agent-test.yaml
+++ b/.github/workflows/azure-devops-agent-test.yaml
@@ -1,4 +1,4 @@
-name: Run Terratests
+name: Run Terratests Azure devops agent
 
 permissions:
     id-token: write

--- a/.github/workflows/azure-devops-agent-test.yaml
+++ b/.github/workflows/azure-devops-agent-test.yaml
@@ -12,6 +12,7 @@ on:
         - 'tests/go.mod'
         - 'tests/go.sum'
         - 'tests/azure_devops_agent_container_app_jobs/**'
+        - 'modules/azure_devops_agent_container_app_jobs/**'
         - '.github/workflows/reusable-execute-submodule-tests.yaml'
         - '.github/workflows/azure-devops-agent-test.yaml'
     pull_request:
@@ -21,6 +22,7 @@ on:
         - 'tests/go.mod'
         - 'tests/go.sum'
         - 'tests/azure_devops_agent_container_app_jobs/**'
+        - 'modules/azure_devops_agent_container_app_jobs/**'
         - '.github/workflows/reusable-execute-submodule-tests.yaml'
         - '.github/workflows/azure-devops-agent-test.yaml'
 

--- a/.github/workflows/github-runner-test.yaml
+++ b/.github/workflows/github-runner-test.yaml
@@ -1,4 +1,4 @@
-name: Run Terratests
+name: Run Terratests Github runner
 
 permissions:
     id-token: write

--- a/modules/azure_devops_agent_container_app_jobs/README.md
+++ b/modules/azure_devops_agent_container_app_jobs/README.md
@@ -79,6 +79,7 @@ Hosts IP will automatically be added to the allow list in the firewall. Remember
 | <a name="input_agent_max_running_jobs"></a> [agent\_max\_running\_jobs](#input\_agent\_max\_running\_jobs) | Maximum number of jobs to run at one time | `string` | `"20"` | no |
 | <a name="input_agent_memory"></a> [agent\_memory](#input\_agent\_memory) | Memory allocated to a runner | `string` | `"1Gi"` | no |
 | <a name="input_agent_pool_name"></a> [agent\_pool\_name](#input\_agent\_pool\_name) | Name of the agent pool in azure devops | `string` | n/a | yes |
+| <a name="input_agent_replica_timeout"></a> [agent\_replica\_timeout](#input\_agent\_replica\_timeout) | The maximum number of seconds a agent replica is allowed to run | `number` | `7200` | no |
 | <a name="input_azp_org_url"></a> [azp\_org\_url](#input\_azp\_org\_url) | URL for your Azure DevOps organization | `string` | n/a | yes |
 | <a name="input_azp_token"></a> [azp\_token](#input\_azp\_token) | Base64 encoded Azure Devops PAT | `string` | n/a | yes |
 | <a name="input_infrastructure_subnet_id"></a> [infrastructure\_subnet\_id](#input\_infrastructure\_subnet\_id) | The subnet\_id where the container app jobs are running. The Subnet must have a /21 or larger address space. | `string` | n/a | yes |

--- a/modules/azure_devops_agent_container_app_jobs/containerapps.tf
+++ b/modules/azure_devops_agent_container_app_jobs/containerapps.tf
@@ -69,7 +69,7 @@ resource "azurerm_container_app_job" "agent" {
   location                     = data.azurerm_resource_group.agent_rg.location
   resource_group_name          = data.azurerm_resource_group.agent_rg.name
   container_app_environment_id = azurerm_container_app_environment.agent_env.id
-  replica_timeout_in_seconds   = 1800
+  replica_timeout_in_seconds   = var.agent_replica_timeout
   tags                         = local.all_tags
   identity {
     type         = "UserAssigned"

--- a/modules/azure_devops_agent_container_app_jobs/variables.tf
+++ b/modules/azure_devops_agent_container_app_jobs/variables.tf
@@ -85,3 +85,9 @@ variable "agent_max_running_jobs" {
   default     = "20"
   description = "Maximum number of jobs to run at one time"
 }
+
+variable "agent_replica_timeout" {
+  default = 7200
+  type    = number
+  description = "The maximum number of seconds a agent replica is allowed to run"
+}

--- a/modules/azure_devops_agent_container_app_jobs/variables.tf
+++ b/modules/azure_devops_agent_container_app_jobs/variables.tf
@@ -87,7 +87,7 @@ variable "agent_max_running_jobs" {
 }
 
 variable "agent_replica_timeout" {
-  default = 7200
-  type    = number
+  default     = 7200
+  type        = number
   description = "The maximum number of seconds a agent replica is allowed to run"
 }

--- a/modules/github_runner_container_app_jobs/README.md
+++ b/modules/github_runner_container_app_jobs/README.md
@@ -87,6 +87,7 @@ Resources will inherit location from resource group
 | <a name="input_runner_labels"></a> [runner\_labels](#input\_runner\_labels) | Additional labels to add to the runner | `string` | `"default"` | no |
 | <a name="input_runner_max_running_jobs"></a> [runner\_max\_running\_jobs](#input\_runner\_max\_running\_jobs) | Maximum number of jobs to run at one time | `string` | `"20"` | no |
 | <a name="input_runner_memory"></a> [runner\_memory](#input\_runner\_memory) | Memory allocated to a runner | `string` | `"1Gi"` | no |
+| <a name="input_runner_replica_timeout"></a> [runner\_replica\_timeout](#input\_runner\_replica\_timeout) | The maximum number of seconds a runner replica is allowed to run | `number` | `7200` | no |
 
 ## Outputs
 

--- a/modules/github_runner_container_app_jobs/containerapps.tf
+++ b/modules/github_runner_container_app_jobs/containerapps.tf
@@ -13,7 +13,7 @@ resource "azurerm_container_app_job" "acaghr_app_job" {
   location                     = data.azurerm_resource_group.acaghr_rg.location
   resource_group_name          = data.azurerm_resource_group.acaghr_rg.name
   container_app_environment_id = azurerm_container_app_environment.acaghr_env.id
-  replica_timeout_in_seconds   = 1800
+  replica_timeout_in_seconds   = var.runner_replica_timeout
   tags                         = local.all_tags
   identity {
     type         = "UserAssigned"

--- a/modules/github_runner_container_app_jobs/variables.tf
+++ b/modules/github_runner_container_app_jobs/variables.tf
@@ -105,7 +105,7 @@ variable "runner_labels" {
 }
 
 variable "runner_replica_timeout" {
-  default = 7200
-  type    = number
+  default     = 7200
+  type        = number
   description = "The maximum number of seconds a runner replica is allowed to run"
 }

--- a/modules/github_runner_container_app_jobs/variables.tf
+++ b/modules/github_runner_container_app_jobs/variables.tf
@@ -103,3 +103,9 @@ variable "runner_labels" {
   type        = string
   description = "Additional labels to add to the runner"
 }
+
+variable "runner_replica_timeout" {
+  default = 7200
+  type    = number
+  description = "The maximum number of seconds a runner replica is allowed to run"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make replica timeout configurable and increase default from 1800 to 7200 seconds

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
